### PR TITLE
🐛 Fix properties named with expressions or predicates

### DIFF
--- a/grammars/sqsp.json
+++ b/grammars/sqsp.json
@@ -7,7 +7,8 @@
     "item",
     "list",
     "page",
-    "region"
+    "region",
+    "jsont"
   ],
 
   "patterns": [

--- a/grammars/sqsp.json
+++ b/grammars/sqsp.json
@@ -56,11 +56,11 @@
       },
       "begin": "\\{(?!#)",
       "patterns": [
+        { "include": "#properties" },
         { "include": "#expressions" },
         { "include": "#predicates" },
         { "include": "#constants" },
         { "include": "#objects" },
-        { "include": "#properties" },
         { "include": "#definitions" },
         { "include": "#formatters" },
         { "include": "#formatters-wargs" },

--- a/spec/test.block
+++ b/spec/test.block
@@ -21,6 +21,7 @@
 {.if @var|image-meta == "my string"}
 {.if collection.description}{.or}{.end}
 {.if title || body}{.end}
+{.if title.if.or.end.section.var}{.end}
 
 {.section website}
   {siteTitle}


### PR DESCRIPTION
Adds support for .jsont files.

Additionally fixes an issue where `{.if foo.bar.if.baz}` would have the rightmost `.if` colored differently than `bar`.

Old:
![image](https://user-images.githubusercontent.com/6043371/66720023-4694ae00-edc5-11e9-8edf-759f21ce66e0.png)

New:
![image](https://user-images.githubusercontent.com/6043371/66720027-4bf1f880-edc5-11e9-937c-fa77d26e1a78.png)

I've verified in the test file this is the only syntax change that occurs.
Test File (old):
![image](https://user-images.githubusercontent.com/6043371/66720021-40063680-edc5-11e9-9f5f-dc39bb8ec65f.png)

Test File (new):
![image](https://user-images.githubusercontent.com/6043371/66720009-28c74900-edc5-11e9-980c-246deb0318a4.png)
